### PR TITLE
Tools

### DIFF
--- a/firebase/firestore-py/bin/admins.py
+++ b/firebase/firestore-py/bin/admins.py
@@ -29,5 +29,5 @@ if __name__ == '__main__':
 	set_claims(admins)
 
 	delete_app(firebase.app)
-	utils.logger.info("Finished settig up admins")
+	utils.logger.info("Finished setting up admins")
 

--- a/firebase/firestore-py/bin/faculty.py
+++ b/firebase/firestore-py/bin/faculty.py
@@ -8,44 +8,46 @@ from lib import services
 
 
 if __name__ == "__main__":
-	utils.logger.info("Indexing data...")
+  utils.logger.info("Indexing data...")
 
-	faculty = utils.logger.log_value(
-		"faculty objects", faculty_reader.get_faculty
-		)
+  faculty = utils.logger.log_value(
+    "faculty objects", faculty_reader.get_faculty
+    )
 
-	section_teachers = utils.logger.log_value(
-		"section teachers", section_reader.get_section_faculty_ids
-		)
-	
-	faculty_sections = utils.logger.log_value(
-		"faculty sections", lambda: faculty_logic.get_faculty_sections(
-			faculty = faculty,
-			section_teachers = section_teachers
-		) 
-	)
+  section_teachers = utils.logger.log_value(
+    "section teachers", section_reader.get_section_faculty_ids
+    )
 
-	periods = utils.logger.log_value(
-		"periods", student_reader.read_periods
-	)
+  faculty_sections = utils.logger.log_value(
+    "faculty sections", lambda: faculty_logic.get_faculty_sections(
+      faculty = faculty,
+      section_teachers = section_teachers
+    ) 
+  )
 
-	faculty_with_schedule = utils.logger.log_value(
-		"faculty with schedule", lambda: faculty_logic.get_faculty_with_schedule(
-			faculty_sections = faculty_sections,
-			section_periods = periods
-		)
-	)
+  periods = utils.logger.log_value(
+    "periods", student_reader.read_periods
+  )
 
-	User.verify_schedule(faculty_with_schedule)
+  faculty_with_schedule = utils.logger.log_value(
+    "faculty with schedule", lambda: faculty_logic.get_faculty_with_schedule(
+      faculty_sections = faculty_sections,
+      section_periods = periods
+    )
+  )
 
-	utils.logger.info("Finished data indexing.")
+  User.verify_schedule(faculty_with_schedule)
 
-	if utils.args.should_upload:
-		utils.logger.log_value(
-			"data upload", lambda: services.upload_users(faculty_with_schedule)
-		)
-	
-	utils.logger.info(f"Processed {len(faculty_with_schedule)} faculty")
+  utils.logger.info("Finished data indexing.")
 
-	
+  if utils.args.should_upload:
+    utils.logger.log_progress(
+      "data upload", lambda: services.upload_users(faculty_with_schedule)
+    )
+  else:
+    utils.logger.warning("Did not upload faculty. Use the --upload flag.")
+  
+  utils.logger.info(f"Processed {len(faculty_with_schedule)} faculty")
+
+  
 

--- a/firebase/firestore-py/bin/sections.py
+++ b/firebase/firestore-py/bin/sections.py
@@ -29,9 +29,11 @@ if __name__ == "__main__":
   print("Finished data indexing.")
 
   if utils.args.should_upload:
-    utils.logger.log_value(
+    utils.logger.log_progress(
       "data upload", lambda: services.upload_sections(sections)
     )
+  else:
+    print("Did not upload sections data. Use the --upload flag.")
   
   utils.logger.info(f"Processed {len(sections)} sections")
 

--- a/firebase/firestore-py/lib/faculty/logic.py
+++ b/firebase/firestore-py/lib/faculty/logic.py
@@ -26,11 +26,8 @@ in order to keep the data and logic layers separate.
 def get_faculty_sections(faculty,section_teachers):
   result = defaultdict(set)
   missing_emails = set()
-  for key, value in section_teachers.items():
-    section_id = key
-    faculty_id = value
-
-    #Teaches a class but doesn't have basic faculty data
+  for section_id, faculty_id in section_teachers.items():
+    # Teaches a class but doesn't have basic faculty data
     if faculty_id not in faculty:
       missing_emails.add(faculty_id)
       continue
@@ -72,7 +69,7 @@ def get_faculty_with_schedule(faculty_sections, section_periods):
     periods = []
     for section_id in value:
       if section_id in section_periods:
-        periods = list(section_periods[section_id])
+        periods.extend(section_periods[section_id])
       elif section_id.startswith("UADV"):
         key.homeroom = section_id
         key.homeroom_location = "Unavailable"

--- a/firebase/firestore-py/lib/sections/logic.py
+++ b/firebase/firestore-py/lib/sections/logic.py
@@ -16,16 +16,16 @@ def get_course_id(section_id):
   else:
     return result
 
-	# Builds a list of [Section] objects.
-	# 
-	# This function works by taking several arguments: 
-	# 
-	# - courseNames, from [section_reader.course_names]
-	# - sectionTeachers, from [section_reader.get_section_faculty_ids]
-	# - facultyNames, from [faculty_reader.get_faculty]
-	# 
-	# These are kept as parameters instead of calling the functions by itself
-	# in order to keep the data and logic layers separate.
+  # Builds a list of [Section] objects.
+  # 
+  # This function works by taking several arguments: 
+  # 
+  # - courseNames, from [section_reader.course_names]
+  # - sectionTeachers, from [section_reader.get_section_faculty_ids]
+  # - facultyNames, from [faculty_reader.get_faculty]
+  # 
+  # These are kept as parameters instead of calling the functions by itself
+  # in order to keep the data and logic layers separate.
 
 def get_sections(course_names, section_teachers, faculty_names, zoom_links):
   return [
@@ -33,7 +33,11 @@ def get_sections(course_names, section_teachers, faculty_names, zoom_links):
       id = key,
       name = course_names[get_course_id(key)],
       teacher = faculty_names[value].name,
-      zoom_link = zoom_links[key] if key in zoom_links else ""
+      # Set's the link to the zoom link attached to a teacher's email
+      # If this teacher has different links to different secions, set it 
+      # to the link attached to their id.
+      # If there is no zoom link attached to an email or a course id, leave it empty.
+      zoom_link = zoom_links[faculty_names[value].email] if faculty_names[value].email in zoom_links else zoom_links[key] if key in zoom_links else ""
     )
     for key, value in section_teachers.items()
   ]

--- a/firebase/firestore-py/lib/sections/reader.py
+++ b/firebase/firestore-py/lib/sections/reader.py
@@ -1,7 +1,5 @@
 import csv
-from logging import log
-from ..utils import dir
-import warnings
+from ..utils import dir, logger
 
 '''
 A collection of functions to read course data.
@@ -24,15 +22,26 @@ def get_section_faculty_ids():
       row["SECTION_ID"]: row["FACULTY_ID"]
       for row in csv.DictReader(file)
       if row["SCHOOL_ID"] == "Upper" and row["FACULTY_ID"]}
+  
       
 def get_zoom_links():
+  Links = {}
   try:
     with open(dir.zoom_links) as file:
-      return {
-        row["ID"]: row["LINK"]
-        for row in csv.DictReader(file)
-        if row["LINK"]
-      }
+      for row in csv.DictReader(file):
+        if row["LINK"]:
+          Links[row["EMAIL"]] = row["LINK"]
+
   except FileNotFoundError:
-    warnings.warn("zoom_links.csv doesn't exist. Cannot grab data. Using an empty dictionary instead")
-    return {}
+    logger.warning("zoom_links.csv doesn't exist. Cannot grab data. Using an empty dictionary instead")
+
+  try:
+    with open(dir.special_zoom_links) as file:
+      for row in csv.DictReader(file):
+        Links[row["ID"]] = row["LINK"]
+
+  except FileNotFoundError:
+    logger.warning("No special zoom links")
+  
+  return Links
+

--- a/firebase/firestore-py/lib/services/auth.py
+++ b/firebase/firestore-py/lib/services/auth.py
@@ -16,3 +16,4 @@ def set_scopes(email, scopes): auth.set_custom_user_claims(
 	get_user(email).uid,
 	{"isAdmin": bool(scopes), "scopes": scopes},
 )
+

--- a/firebase/firestore-py/lib/utils/dir.py
+++ b/firebase/firestore-py/lib/utils/dir.py
@@ -37,8 +37,12 @@ section_schedule = data_dir / "section_schedule.csv"
 # Contains the names, emails, and IDs of every student.
 students = data_dir / "students.csv"
 
-# The virtual class links.
+# The virtual class links connecting a zoom link to a teacher's email.
 zoom_links = data_dir / "zoom_links.csv"
+
+# The virtual class links connecting a zoom link to a section Id.
+special_zoom_links = data_dir / "special_zoom_links.csv"
+
 
 # The list of admins.
 # 

--- a/firebase/firestore-py/lib/utils/logger.py
+++ b/firebase/firestore-py/lib/utils/logger.py
@@ -9,37 +9,37 @@ reset = Style.RESET_ALL
 def get_ansi(code): return f"\u001b[38;5;{code}m"
 
 class ColorFormatter(logging.Formatter):
-	def __init__(self, use_color = True):
-		self.use_color = use_color
+  def __init__(self, use_color = True):
+    self.use_color = use_color
 
-	FORMATS = {
-		logging.DEBUG: Fore.WHITE,
-		logging.VERBOSE: Style.BRIGHT + Fore.BLACK,
-		logging.INFO: Fore.BLUE,
-		logging.WARNING: Fore.YELLOW,
-		logging.ERROR: Fore.RED,
-	}
+  FORMATS = {
+    logging.DEBUG: Fore.WHITE,
+    logging.VERBOSE: Style.BRIGHT + Fore.BLACK,
+    logging.INFO: Fore.BLUE,
+    logging.WARNING: Fore.YELLOW,
+    logging.ERROR: Fore.RED,
+  }
 
-	def format(self, record):
-		color = self.FORMATS[record.levelno]
-		if self.use_color: 
-			formatter = logging.Formatter(f"{color}[{record.levelname[0]}]{reset} %(message)s")
-		else: 
-			formatter = logging.Formatter(f"[{record.levelname[0]}] %(message)s")
-		return formatter.format(record)
+  def format(self, record):
+    color = self.FORMATS[record.levelno]
+    if self.use_color: 
+      formatter = logging.Formatter(f"{color}[{record.levelname[0]}]{reset} %(message)s")
+    else: 
+      formatter = logging.Formatter(f"[{record.levelname[0]}] %(message)s")
+    return formatter.format(record)
 
 def verbose(self, message, *args, **kwargs): 
-	if self.isEnabledFor(logging.VERBOSE):
-		self._log(logging.VERBOSE, message, args, **kwargs) 
+  if self.isEnabledFor(logging.VERBOSE):
+    self._log(logging.VERBOSE, message, args, **kwargs) 
 
 def debug(self, label, value, *args, **kwargs): 
-	if self.isEnabledFor(logging.DEBUG): 
-		self._log(logging.DEBUG, f"{label}: {value}", args, **kwargs)
+  if self.isEnabledFor(logging.DEBUG): 
+    self._log(logging.DEBUG, f"{label}: {value}", args, **kwargs)
 
 def error(self, message, *args, **kwards): 
-	if self.isEnabledFor(logging.ERROR):
-		self._log(logging.ERROR, message, args, **kwards)
-		raise AssertionError(message)
+  if self.isEnabledFor(logging.ERROR):
+    self._log(logging.ERROR, message, args, **kwards)
+    raise AssertionError(message)
 
 logging.addLevelName(logging.VERBOSE, "VERBOSE")  # between INFO and DEBUG
 logging.Logger.verbose = verbose
@@ -50,42 +50,41 @@ logger = logging.getLogger("ramlife")
 console_handler = logging.StreamHandler()
 console_handler.setFormatter(ColorFormatter())
 if args.verbose: 
-	logger.setLevel(logging.VERBOSE)
-	console_handler.setLevel(logging.VERBOSE)
+  logger.setLevel(logging.VERBOSE)
+  console_handler.setLevel(logging.VERBOSE)
 elif args.debug:
-	logger.setLevel(logging.DEBUG)
-	console_handler.setLevel(logging.VERBOSE)
+  logger.setLevel(logging.DEBUG)
+  console_handler.setLevel(logging.VERBOSE)
 else: 
-	logger.setLevel(logging.INFO)
-	console_handler.setLevel(logging.INFO)
+  logger.setLevel(logging.INFO)
+  console_handler.setLevel(logging.INFO)
 logger.addHandler(console_handler)
 
 if args.debug: 
-	file_handler = logging.FileHandler("debug.log", encoding='utf8')
-	file_handler.setFormatter(ColorFormatter(False))
-	file_handler.setLevel(logging.DEBUG)
-	logger.addHandler(file_handler)
+  file_handler = logging.FileHandler("debug.log", encoding='utf8')
+  file_handler.setFormatter(ColorFormatter(False))
+  file_handler.setLevel(logging.DEBUG)
+  logger.addHandler(file_handler)
 
-def log_value(label, function): 
-	"""
-	Emits logs before and after returning a value.
-	
-	Emits a [verbose] log before calling [func], then a [debug] log with the 
-	result, and finally returns the result. 
-	
-	The [label] should be all lower case, since it will appear in the middle
-	of the logged messages. 
-	"""
-
-	logger.verbose(f"Getting {label}")
-	value = function()
-	logger.debug(f"Value of {label}", value)
-	return value
+def log_value(label, function):
+  """
+  Emits logs before and after returning a value.
+  
+  Emits a [verbose] log before calling [func], then a [debug] log with the 
+  result, and finally returns the result. 
+  
+  The [label] should be all lower case, since it will appear in the middle
+  of the logged messages. 
+  """
+  logger.verbose(f"Getting {label}")
+  value = function()
+  logger.debug(f"Value of {label}", value)
+  return value
 
 def log_progress(label, function): 
-	logger.info(f"Starting {label}")
-	function()
-	logger.info(f"Finished {label}")
+  logger.info(f"Starting {label}")
+  function()
+  logger.info(f"Finished {label}")
 
 logger.log_progress = log_progress
 logger.log_value = log_value

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -302,7 +302,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
@@ -489,7 +489,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.2"
   timezone:
     dependency: transitive
     description:


### PR DESCRIPTION
Changed how zoom links work:
The zoom_links.csv file's first column has teacher emails and the second has their zoom link for all classes.
This accommodates teachers (which is most of them) who have one link for all of their classes.

Then there's another file, special_zoom_links.csv whose first column is section ids and the second is zoom link. 
This accommodates teachers who have a different link for each class.

In the reader file, both pairings, email:link and id:link , are added to the zoom_links dictionary
which then gets handled to properly assign a link to a class. 